### PR TITLE
Add a Lumen coding-agent adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__/
 config.yaml
 outputs/
 run_outputs/
+
+# built lumen agent binary (see docker/Dockerfile.lumen)
+docker/lumen

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -9,6 +9,7 @@ from .dummy import DummyAgent
 from .codex import CodexAgent
 from .claude import ClaudeAgent
 from .gemini import GeminiAgent
+from . import lumen_adapter  # noqa: F401  (registers the Lumen adapter on import)
 
 __all__ = ["BaseAgent", "DummyAgent", "CodexAgent", "ClaudeAgent", "GeminiAgent"]
 

--- a/agent/lumen_adapter.py
+++ b/agent/lumen_adapter.py
@@ -1,0 +1,107 @@
+"""NatureBench adapter for the Lumen coding agent (https://github.com/…/lumen).
+
+Lumen is a single static Go binary run non-interactively as ``lumen run
+<prompt>``. It runs the agent loop to completion and exits, auto-approving tool
+calls in headless mode — which matches NatureBench's container execution model
+(``docker exec`` a one-shot command, no TTY, the agent submits to the eval
+service over HTTP and then returns).
+
+Design notes
+------------
+* **Prompt** — reuses the built-in Claude task prompt verbatim. The NatureBench
+  evaluation protocol (DATA_DIR / OUTPUT_DIR / submit to ``$EVAL_SERVICE_URL``)
+  is model-agnostic plain-text instructions, so handing Lumen the same prompt
+  keeps its score comparable with the built-in CLIs.
+* **Model / provider** — ``lumen run`` has no ``--model`` flag; model and
+  provider come from ``lumen.toml`` (found in the working dir) plus an API key
+  from the environment. ``build_command`` therefore writes a ``lumen.toml`` into
+  ``/workspace`` (Lumen's cwd, which it searches first) with the requested model
+  before launching. Defaults target DeepSeek (OpenAI-compatible); override the
+  endpoint with ``DEEPSEEK_BASE_URL`` in the host env.
+* **No web** — the config pins the ``core`` tool profile, so Lumen is not handed
+  its web/search tools (NatureBench disallows web access for the built-ins too).
+* **Auto-approve** — ``--mode bypass`` plus Lumen's headless auto-approve means
+  no interactive permission prompt can stall the run.
+"""
+from __future__ import annotations
+
+import os
+from typing import List
+
+from .adapter import REGISTRY, AgentAdapter, AgentRunContext
+from .claude import ClaudeAgent
+
+# Resume notice mirrors the built-in adapters: Lumen's `run` is stateless across
+# container restarts, but /workspace and any prior /evaluate submissions are
+# preserved on disk, so "continue from the workspace" is the right instruction.
+_RESUME_PROMPT = (
+    "[RESUME NOTICE] You were previously interrupted on this task. "
+    "The /workspace contents and any prior /evaluate submissions are preserved. "
+    "Continue from where you left off. "
+    "**Use the full remaining time budget**: keep iterating, profiling, and "
+    "refining until `/time_remaining` is close to zero. Do **not** exit early "
+    "just because you have a working baseline. Check `/time_remaining` first."
+)
+
+# Default provider endpoint (DeepSeek is OpenAI-compatible). Overridable per-run
+# via the DEEPSEEK_BASE_URL host env var so the same adapter can point Lumen at a
+# local OpenAI-compatible server without code changes.
+_DEFAULT_BASE_URL = "https://api.deepseek.com/v1"
+
+
+class LumenAdapter(AgentAdapter):
+    name = "lumen"
+
+    def system_prompt(self, ctx: AgentRunContext) -> str:
+        if ctx.is_resume:
+            return _RESUME_PROMPT
+        return ClaudeAgent(model_name=ctx.model, mode=ctx.mode).build_system_prompt({
+            "task_name": ctx.task_name,
+            "batch_name": ctx.batch_name,
+            "eval_service_url": ctx.eval_service_url,
+            "eval_output_dir": ctx.eval_output_dir,
+            "time_limit_minutes": ctx.time_limit_minutes,
+        })
+
+    def build_command(self, ctx: AgentRunContext) -> List[str]:
+        base_url = os.environ.get("DEEPSEEK_BASE_URL") or _DEFAULT_BASE_URL
+        # Lumen finds ./lumen.toml in its cwd (/workspace) first. Write it there
+        # with the requested model, then exec the agent. The prompt is passed as
+        # the positional "$1" so the (large, multi-line) system prompt never has
+        # to be escaped into the script body — solve.py shlex-quotes each argv
+        # element, so "$1" resolves to exactly ctx.system_prompt.
+        config = (
+            'default_model = "deepseek"\n'
+            "\n"
+            "[tools]\n"
+            'profile = "core"\n'
+            "\n"
+            "[[providers]]\n"
+            'name = "deepseek"\n'
+            'kind = "openai"\n'
+            f'base_url = "{base_url}"\n'
+            f'model = "{ctx.model}"\n'
+            'api_key_env = "DEEPSEEK_API_KEY"\n'
+        )
+        script = (
+            "set -e\n"
+            "mkdir -p /workspace\n"
+            "cat > /workspace/lumen.toml <<'LUMEN_TOML_EOF'\n"
+            f"{config}"
+            "LUMEN_TOML_EOF\n"
+            'exec lumen run --mode bypass "$1"\n'
+        )
+        return ["bash", "-lc", script, "lumen", ctx.system_prompt]
+
+    def extra_env(self, ctx: AgentRunContext) -> List[str]:
+        # solve.py forwards only the Anthropic/OpenAI/Gemini keys, so the Lumen
+        # adapter forwards its own provider key from the host environment.
+        env: List[str] = []
+        for key in ("DEEPSEEK_API_KEY", "DEEPSEEK_BASE_URL"):
+            val = os.environ.get(key)
+            if val:
+                env.extend(["-e", f"{key}={val}"])
+        return env
+
+
+REGISTRY.register(LumenAdapter())

--- a/agent/lumen_adapter_test.py
+++ b/agent/lumen_adapter_test.py
@@ -1,0 +1,87 @@
+"""Tests for the Lumen agent adapter.
+
+These pin the contract solve.py relies on: the adapter registers under "lumen",
+its system prompt carries the NatureBench eval protocol, and its in-container
+command writes a lumen.toml + launches `lumen run` non-interactively with the
+task prompt as the positional argument.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import agent  # noqa: F401  (importing the package registers the adapter)
+from agent.adapter import REGISTRY, AgentRunContext
+
+
+def _ctx(**overrides) -> AgentRunContext:
+    base = dict(
+        system_prompt="",
+        model="deepseek-chat",
+        mode="base",
+        task_name="some_task",
+        batch_name="some_batch",
+        eval_service_url="http://host.docker.internal:9000",
+        eval_output_dir="/workspace/output",
+        time_limit_minutes=60,
+    )
+    base.update(overrides)
+    return AgentRunContext(**base)
+
+
+def test_adapter_is_registered():
+    assert REGISTRY.has("lumen")
+    assert "lumen" in REGISTRY.names()
+
+
+def test_system_prompt_carries_eval_protocol():
+    ctx = _ctx()
+    prompt = REGISTRY.get("lumen").system_prompt(ctx)
+    assert ctx.eval_service_url in prompt
+    assert ctx.task_name in prompt
+    assert "/evaluate" in prompt
+
+
+def test_system_prompt_resume_is_a_notice():
+    prompt = REGISTRY.get("lumen").system_prompt(_ctx(is_resume=True))
+    assert "RESUME NOTICE" in prompt
+
+
+def test_build_command_shape_and_prompt_passthrough():
+    ctx = _ctx(system_prompt="THE-SYSTEM-PROMPT\nwith newlines")
+    cmd = REGISTRY.get("lumen").build_command(ctx)
+    # bash -lc <script> <argv0> <prompt>
+    assert cmd[0] == "bash"
+    assert cmd[1] == "-lc"
+    # The (possibly huge, multi-line) prompt is the last argv element verbatim,
+    # so solve.py's shlex-quote makes it land in the script's "$1".
+    assert cmd[-1] == ctx.system_prompt
+    script = cmd[2]
+    assert 'lumen run --mode bypass "$1"' in script
+    assert "lumen.toml" in script
+
+
+def test_build_command_embeds_requested_model():
+    cmd = REGISTRY.get("lumen").build_command(_ctx(model="deepseek-reasoner"))
+    assert 'model = "deepseek-reasoner"' in cmd[2]
+    assert 'profile = "core"' in cmd[2]  # no web tools
+
+
+def test_extra_env_forwards_deepseek_key(monkeypatch):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-xyz")
+    monkeypatch.delenv("DEEPSEEK_BASE_URL", raising=False)
+    env = REGISTRY.get("lumen").extra_env(_ctx())
+    assert env == ["-e", "DEEPSEEK_API_KEY=sk-xyz"]
+
+
+def test_extra_env_empty_without_key(monkeypatch):
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    monkeypatch.delenv("DEEPSEEK_BASE_URL", raising=False)
+    assert REGISTRY.get("lumen").extra_env(_ctx()) == []
+
+
+def test_base_url_override_flows_into_config(monkeypatch):
+    monkeypatch.setenv("DEEPSEEK_BASE_URL", "http://localhost:1234/v1")
+    cmd = REGISTRY.get("lumen").build_command(_ctx())
+    assert 'base_url = "http://localhost:1234/v1"' in cmd[2]

--- a/docker/Dockerfile.lumen
+++ b/docker/Dockerfile.lumen
@@ -1,0 +1,29 @@
+# ==============================================================================
+# NatureBench base image + the Lumen coding agent
+# ==============================================================================
+# Lumen is a single static Go binary, so adding it to the task runtime is just a
+# COPY — no package manager, no language runtime. Build the linux/amd64 binary
+# first (from the lumen repo), drop it next to this Dockerfile, then:
+#
+#   # 1. cross-compile the agent (in the lumen checkout):
+#   CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" \
+#       -o /path/to/NatureBench/docker/lumen ./cmd/lumen
+#
+#   # 2. build the image (needs naturebench-base:v3 present — see
+#   #    scripts/ensure_naturebench_base.sh):
+#   docker build -t naturebench-lumen:v3 -f docker/Dockerfile.lumen docker
+#
+#   # 3. run a task on it:
+#   DEEPSEEK_API_KEY=sk-... python run_naturebench.py \
+#       --agent lumen --model deepseek-chat --tasks cpu \
+#       --skip-build --base-image naturebench-lumen:v3
+# ==============================================================================
+FROM naturebench-base:v3
+
+# Static binary → no runtime deps. Installed on PATH as `lumen`.
+COPY lumen /usr/local/bin/lumen
+RUN chmod +x /usr/local/bin/lumen && lumen version
+
+# The adapter writes a per-run lumen.toml into /workspace at launch, so no
+# baked config is required here. The DeepSeek API key is forwarded by the
+# adapter's extra_env() from the host environment at run time.

--- a/docs/agent-lumen.md
+++ b/docs/agent-lumen.md
@@ -1,0 +1,69 @@
+# Running NatureBench with the Lumen agent
+
+[Lumen](https://github.com/) is a terminal coding agent shipped as a single
+static Go binary. It is wired into NatureBench through the standard
+[`AgentAdapter`](../agent/adapter.py) interface (see
+[custom-agents.md](custom-agents.md), Path B) — no changes to `solve.py`.
+
+## How it works
+
+| Piece | Where |
+|---|---|
+| Adapter | [`agent/lumen_adapter.py`](../agent/lumen_adapter.py) — registers as `lumen` |
+| Registration | imported from [`agent/__init__.py`](../agent/__init__.py), so `solve.py`'s `import agent.cli_adapters` picks it up |
+| Image | [`docker/Dockerfile.lumen`](../docker/Dockerfile.lumen) — `naturebench-base:v3` + the `lumen` binary |
+
+The adapter:
+
+- **Prompt** — reuses the built-in Claude task prompt verbatim, so the evaluation
+  protocol (write to `OUTPUT_DIR`, submit to `$EVAL_SERVICE_URL/evaluate`) is
+  identical to the built-in CLIs and the score stays comparable.
+- **Launch** — `lumen run --mode bypass "<prompt>"`. Headless Lumen auto-approves
+  tool calls and never blocks on a TTY prompt, so it runs to completion and exits.
+- **Model / provider** — `lumen run` has no `--model` flag; the adapter writes a
+  `lumen.toml` into `/workspace` at launch with the requested model and the
+  `core` tool profile (no web tools, matching the built-ins' `--disallowedTools`).
+  Defaults target DeepSeek (OpenAI-compatible). The provider key is forwarded
+  from the host env (`DEEPSEEK_API_KEY`); override the endpoint with
+  `DEEPSEEK_BASE_URL` to point at any OpenAI-compatible server (e.g. a local
+  model).
+
+## One-time setup
+
+```bash
+# 1. Cross-compile the linux/amd64 binary in your lumen checkout:
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" \
+    -o /path/to/NatureBench/docker/lumen ./cmd/lumen
+
+# 2. Ensure the base image exists, then build the Lumen image:
+bash scripts/ensure_naturebench_base.sh
+docker build -t naturebench-lumen:v3 -f docker/Dockerfile.lumen docker
+```
+
+## Run
+
+```bash
+export DEEPSEEK_API_KEY=sk-...        # provider key (forwarded into the container)
+
+python run_naturebench.py \
+    --agent lumen --model deepseek-chat \
+    --tasks cpu \
+    --skip-build --base-image naturebench-lumen:v3 \
+    --start-eval-services --eval-env-mapping eval_env_mapping.json
+```
+
+`--model` accepts any model valid for the configured provider (e.g.
+`deepseek-chat`, `deepseek-reasoner`). Swap `--tasks cpu` for `gpu_low` /
+`gpu_high` / `all` once a GPU host is available — note 87 of the 90 tasks
+require CUDA, so a CPU-only host can only run the 3 `cpu` tasks.
+
+## Verifying the integration without a full run
+
+```bash
+# adapter unit tests (registration, command shape, env forwarding):
+python -m pytest agent/lumen_adapter_test.py -q
+
+# confirm solve.py will accept --agent lumen:
+python -c "import agent.cli_adapters; from agent.adapter import REGISTRY; \
+print(REGISTRY.names())"
+```


### PR DESCRIPTION
## Add a Lumen coding-agent adapter

This adds the [Lumen](https://github.com/exergyleizhou-ux/lumen) terminal coding agent as a NatureBench harness, via the documented `AgentAdapter` interface (Path B in `docs/custom-agents.md`). **No changes to `solve.py`** — the adapter registers itself like the built-in Claude/Codex/Gemini CLIs.

### Why it fits cleanly
Lumen is a single static Go binary that runs non-interactively as `lumen run <prompt>`, runs the agent loop to completion, and auto-approves tool calls in headless mode — matching NatureBench's `docker exec` execution model. It reuses the built-in Claude task prompt verbatim, so the evaluation protocol (write to `OUTPUT_DIR`, submit to `$EVAL_SERVICE_URL/evaluate`) is identical and scores stay comparable.

### What's here
- `agent/lumen_adapter.py` — `LumenAdapter` (`system_prompt` / `build_command` / `extra_env`). Writes a per-run `lumen.toml` with the requested model and the `core` tool profile (no web tools, matching the built-ins' `--disallowedTools`); forwards `DEEPSEEK_API_KEY` from the host env.
- `agent/lumen_adapter_test.py` — 8 tests: registration, command shape, prompt passthrough, env forwarding.
- `agent/__init__.py` — registers the adapter on import (so `solve.py`'s `import agent.cli_adapters` picks it up).
- `docker/Dockerfile.lumen` — `naturebench-base:v3` + the lumen binary.
- `docs/agent-lumen.md` — setup + run instructions.

### Verification
- `python -m pytest agent/lumen_adapter_test.py -q` → 8 passed
- `import agent.cli_adapters; REGISTRY.names()` → `['claude', 'codex', 'gemini', 'lumen']`
- The in-container launch wrapper was smoke-tested in a linux/amd64 container through to the model API call.

### Run
```bash
export DEEPSEEK_API_KEY=sk-...
python run_naturebench.py --agent lumen --model deepseek-chat --tasks cpu \
    --skip-build --base-image naturebench-lumen:v3
```

A scored run additionally needs the base image + a funded provider key; the adapter itself is provider-agnostic (point `DEEPSEEK_BASE_URL` at any OpenAI-compatible endpoint).
